### PR TITLE
Fix authenticated recording playback

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -555,36 +555,44 @@ public:
       const kodi::addon::PVRRecording& recording,
       std::vector<kodi::addon::PVRStreamProperty>& properties) override
   {
-    // Return the stream URL for playback.
-    // The Dispatcharr /api/channels/recordings/{id}/file/ endpoint allows anonymous access,
-    // so we can simply provide the URL directly without auth headers.
+    // Return an authenticated Dispatcharr recording URL for playback.
+    // The recording file endpoint accepts JWT authentication via the
+    // `token` query parameter.
     if (!m_dispatcharrClient)
       return PVR_ERROR_SERVER_ERROR;
 
-    // Fetch recordings to get the stream URL for this recording ID
-    std::vector<dispatcharr::Recording> recordings;
-    if (!m_dispatcharrClient->FetchRecordings(recordings))
+    const std::string recordingId = recording.GetRecordingId();
+
+    int id = 0;
+    try
     {
-      kodi::Log(ADDON_LOG_ERROR, "pvr.dispatcharr: Failed to fetch recordings for stream properties");
+      id = std::stoi(recordingId);
+    }
+    catch (...)
+    {
+      kodi::Log(ADDON_LOG_ERROR,
+                "pvr.dispatcharr: Invalid recording ID '%s'",
+                recordingId.c_str());
+      return PVR_ERROR_INVALID_PARAMETERS;
+    }
+
+    std::string streamUrl;
+    if (!m_dispatcharrClient->GetRecordingStreamUrl(id, streamUrl))
+    {
+      kodi::Log(ADDON_LOG_ERROR,
+                "pvr.dispatcharr: Failed to prepare playback for recording %s",
+                recordingId.c_str());
       return PVR_ERROR_SERVER_ERROR;
     }
 
-    const std::string recordingId = recording.GetRecordingId();
-    for (const auto& r : recordings)
-    {
-      if (std::to_string(r.id) == recordingId)
-      {
-        if (!r.streamUrl.empty())
-        {
-          properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, r.streamUrl);
-          kodi::Log(ADDON_LOG_DEBUG, "pvr.dispatcharr: Recording stream URL: %s", r.streamUrl.c_str());
-        }
-        return PVR_ERROR_NO_ERROR;
-      }
-    }
+    properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, streamUrl);
 
-    kodi::Log(ADDON_LOG_WARNING, "pvr.dispatcharr: Recording %s not found", recordingId.c_str());
-    return PVR_ERROR_INVALID_PARAMETERS;
+    // Do not log streamUrl: it contains the short-lived playback JWT.
+    kodi::Log(ADDON_LOG_DEBUG,
+              "pvr.dispatcharr: Recording stream URL prepared for recording %s",
+              recordingId.c_str());
+
+    return PVR_ERROR_NO_ERROR;
   }
 
   PVR_ERROR GetTimerTypes(std::vector<kodi::addon::PVRTimerType>& types) override

--- a/src/dispatcharr_client.cpp
+++ b/src/dispatcharr_client.cpp
@@ -302,7 +302,10 @@ std::string Client::GetBaseUrl() const
   return ss.str();
 }
 
-Client::HttpResponse Client::Request(const std::string& method, const std::string& endpoint, const std::string& jsonBody)
+Client::HttpResponse Client::Request(const std::string& method,
+                                     const std::string& endpoint,
+                                     const std::string& jsonBody,
+                                     bool retryAuth)
 {
   HttpResponse resp;
   std::string url = GetBaseUrl() + endpoint;
@@ -369,6 +372,18 @@ Client::HttpResponse Client::Request(const std::string& method, const std::strin
   
   curl_slist_free_all(headers);
   curl_easy_cleanup(curl);
+
+  // If Dispatcharr rejects the cached access token, obtain a new one and retry
+  // the request exactly once.
+  if (resp.statusCode == 401 && retryAuth && !m_accessToken.empty())
+  {
+    kodi::Log(ADDON_LOG_INFO,
+              "pvr.dispatcharr: Access token rejected; re-authenticating and retrying request");
+    m_accessToken.clear();
+
+    if (EnsureToken())
+      return Request(method, endpoint, jsonBody, false);
+  }
   
   return resp;
 }
@@ -385,7 +400,6 @@ bool Client::EnsureToken()
   std::string url = GetBaseUrl() + "/api/accounts/token/";
   kodi::Log(ADDON_LOG_DEBUG, "pvr.dispatcharr: EnsureToken - URL: %s", url.c_str());
   kodi::Log(ADDON_LOG_DEBUG, "pvr.dispatcharr: EnsureToken - Username: %s", m_settings.username.c_str());
-  kodi::Log(ADDON_LOG_DEBUG, "pvr.dispatcharr: EnsureToken - POST body: %s", jsonBody.c_str());
   
   // Use libcurl directly for authentication
   CURL* curl = curl_easy_init();
@@ -419,7 +433,6 @@ bool Client::EnsureToken()
     
     kodi::Log(ADDON_LOG_DEBUG, "pvr.dispatcharr: EnsureToken - HTTP code: %ld", httpCode);
     kodi::Log(ADDON_LOG_DEBUG, "pvr.dispatcharr: EnsureToken - Response body length: %zu", responseBody.size());
-    kodi::Log(ADDON_LOG_DEBUG, "pvr.dispatcharr: EnsureToken - Response body (first 500 chars): %s", responseBody.substr(0, 500).c_str());
     
     if (httpCode == 200) {
       std::string token;
@@ -705,13 +718,47 @@ bool Client::FetchRecordings(std::vector<Recording>& outRecordings)
           r.status = "scheduled";
       }
       
-      // Stream URL
-      // /api/channels/recordings/{id}/file/
-      r.streamUrl = GetBaseUrl() + "/api/channels/recordings/" + std::to_string(r.id) + "/file/";
-      
       outRecordings.push_back(r);
     }
   });
+  return true;
+}
+
+bool Client::GetRecordingStreamUrl(int id, std::string& outUrl)
+{
+  outUrl.clear();
+
+  // Refresh the recording list first. Besides confirming that the recording
+  // still exists, this makes an authenticated request and therefore exercises
+  // Request()'s 401 re-authentication path if the cached access token expired.
+  std::vector<Recording> recordings;
+  if (!FetchRecordings(recordings))
+    return false;
+
+  const auto it = std::find_if(
+      recordings.begin(), recordings.end(),
+      [id](const Recording& recording) { return recording.id == id; });
+
+  if (it == recordings.end())
+  {
+    kodi::Log(ADDON_LOG_WARNING,
+              "pvr.dispatcharr: Recording %d not found", id);
+    return false;
+  }
+
+  if (m_accessToken.empty())
+  {
+    kodi::Log(ADDON_LOG_ERROR,
+              "pvr.dispatcharr: Cannot create recording playback URL without authentication");
+    return false;
+  }
+
+  // Dispatcharr's recording file endpoint accepts JWT authentication through
+  // the `token` query parameter for clients that cannot attach Authorization
+  // headers to media requests.
+  outUrl = GetBaseUrl() + "/api/channels/recordings/" +
+           std::to_string(id) + "/file/?token=" + m_accessToken;
+
   return true;
 }
 

--- a/src/dispatcharr_client.h
+++ b/src/dispatcharr_client.h
@@ -43,7 +43,6 @@ struct Recording
   int channelId = 0;
   std::string title;
   std::string plot;
-  std::string streamUrl;
   std::string status;  // "scheduled", "recording", "completed", "interrupted"
   std::string iconPath; // poster_url from custom_properties
   time_t startTime = 0;
@@ -91,6 +90,7 @@ public:
 
   // Recordings
   bool FetchRecordings(std::vector<Recording>& outRecordings);
+  bool GetRecordingStreamUrl(int id, std::string& outUrl);
   bool DeleteRecording(int id);
   bool ScheduleRecording(int channelId, time_t startTime, time_t endTime, const std::string& title);
 
@@ -107,7 +107,10 @@ private:
     std::string body;
   };
   
-  HttpResponse Request(const std::string& method, const std::string& endpoint, const std::string& jsonBody = "");
+  HttpResponse Request(const std::string& method,
+                       const std::string& endpoint,
+                       const std::string& jsonBody = "",
+                       bool retryAuth = true);
   std::string GetBaseUrl() const;
   bool EnsureChannelMapping();
 };


### PR DESCRIPTION
## Summary

Fix recording playback against current Dispatcharr versions, where the
recording file endpoint requires authentication.

- Authenticate recording playback using Dispatcharr's supported `token`
  query parameter.
- Retry Dispatcharr API requests once after a 401 by obtaining a fresh JWT.
- Avoid logging the authentication POST body, JWT response body, or the
  tokenized recording playback URL.
- Keep recording metadata separate from the short-lived playback URL.

## Why

Dispatcharr recording playback now requires authentication. The addon
previously returned:

`/api/channels/recordings/{id}/file/`

without authentication, resulting in HTTP 403 during playback.

## Testing

Tested successfully with:

- Kodi 21.3 native build
- CoreELEC 21.3 ARM cross-build
- ODROID N2+ running CoreELEC 21.3
- Actual Dispatcharr recording playback

The previously failing recording now plays successfully.

Fixes #15